### PR TITLE
robots.txt: Disallow recommended Cloudflare endpoints

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -32,6 +32,9 @@ Disallow: /*?page=
 Disallow: /*?filter=
 Disallow: /api/
 
+# Disallow recommended Cloudflare endpoints
+Disallow: /cdn-cgi/
+
 # Increased crawl rate for item pages
 Crawl-delay: 0.5
 


### PR DESCRIPTION
This PR disallows Cloudflare's `/cdn-cgi/` endpoint in robots.txt.

Reason: https://developers.cloudflare.com/fundamentals/reference/cdn-cgi-endpoint/#disallow-using-robotstxt

I noticed robots.txt was being updated, so I thought I'd chip in.