### PR TITLE
Potential fix for code scanning alert no. 6: DOM text reinterpreted as HTML

### DIFF
--- a/scripts/dupes.js
+++ b/scripts/dupes.js
@@ -5,6 +5,20 @@ let currentItemId = null;
 let selectedItem = null;
 let currentDuperName = null;
 
+// Function to escape HTML special characters
+function escapeHTML(str) {
+  return str.replace(/[&<>"']/g, function (match) {
+    const escapeMap = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;'
+    };
+    return escapeMap[match];
+  });
+}
+
 let displayedItems = [];
 let currentPage = 0;
 const ITEMS_PER_PAGE = 32;
@@ -574,7 +588,7 @@ async function calculateDupe() {
       <div class="results-card is-dupe">
         <h4>Found ${validDupeItems.length} duped item${
       validDupeItems.length !== 1 ? "s" : ""
-    } for ${duper}</h4>
+    } for ${escapeHTML(duper)}</h4>
         <p class="text-muted">Last recorded dupe: ${formatDate(
           latestDupeDate
         )}</p>


### PR DESCRIPTION
Potential fix for [https://github.com/JBChangelogs/JailbreakChangelogs/security/code-scanning/6](https://github.com/JBChangelogs/JailbreakChangelogs/security/code-scanning/6)

To fix this issue, we need to ensure that any user-controlled data is properly escaped before being inserted into the HTML. This can be achieved by using a function to escape HTML special characters. We will create a utility function `escapeHTML` to escape the special characters and use it to sanitize the `duper` value before including it in the HTML template.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
