### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/scripts/login.js
+++ b/scripts/login.js
@@ -62,7 +62,7 @@ $(document).ready(function () {
   // Store original path before OAuth redirect
   if (
     !window.location.pathname.startsWith("/login") &&
-    !window.location.href.includes("discord.com")
+    !(new URL(window.location.href).host === "discord.com")
   ) {
     LoginLogger.log(
       "redirect",


### PR DESCRIPTION
Potential fix for [https://github.com/JBChangelogs/JailbreakChangelogs/security/code-scanning/4](https://github.com/JBChangelogs/JailbreakChangelogs/security/code-scanning/4)

To fix the problem, we need to parse the URL and check the host component explicitly. This ensures that the check is performed on the correct part of the URL, preventing any bypasses through URL manipulation.

1. Parse the URL using the `URL` constructor to extract the host component.
2. Check if the host matches the allowed host (`discord.com` in this case).
3. Replace the substring check with this more robust host check.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
