### PR TITLE
Potential fix for code scanning alert no. 19: Incomplete URL substring sanitization

### DIFF
--- a/scripts/dupes.js
+++ b/scripts/dupes.js
@@ -1391,7 +1391,14 @@ async function submitDupeReport() {
   const dupeUser = document.getElementById("dupeUserInput").value.trim();
   const proofUrls = Array.from(document.getElementsByClassName("proof-url"))
     .map((input) => input.value.trim())
-    .filter((url) => url && url.includes("imgur.com"));
+    .filter((url) => {
+      try {
+        const parsedUrl = new URL(url);
+        return parsedUrl.host === "imgur.com" || parsedUrl.host.endsWith(".imgur.com");
+      } catch (e) {
+        return false;
+      }
+    });
 
   const token = getCookie("token");
   if (!token) {


### PR DESCRIPTION
Potential fix for [https://github.com/JBChangelogs/JailbreakChangelogs/security/code-scanning/19](https://github.com/JBChangelogs/JailbreakChangelogs/security/code-scanning/19)

To fix the problem, we need to parse the URL and check its host value explicitly. This ensures that the check handles arbitrary subdomain sequences correctly and prevents bypassing the validation by embedding the allowed host in unexpected locations.

The best way to fix the problem without changing existing functionality is to use the `URL` constructor to parse the URL and then check the host against a whitelist of allowed hosts. This approach is more robust and secure.

We will modify the `submitDupeReport` function to include this validation. Specifically, we will replace the substring check with a host check using the `URL` constructor.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
