### PR TITLE
fix: wiki link

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -308,7 +308,7 @@ export default async function RootLayout({
                     </h3>
                     <div className="space-y-2">
                       <a
-                        href="https://jailbreak.fandom.com/wiki/Jailbreak_Wiki"
+                        href="https://jailbreak.fandom.com/wiki/Jailbreak_Wiki:Home"
                         target="_blank"
                         rel="noopener noreferrer"
                         className="flex items-center gap-2 text-muted hover:text-[#FFFFFF]"


### PR DESCRIPTION
Currently, the link for the Jailbreak Wiki in the footer goes to a broken page. This PR fixes the link so it goes to the home page.

Broken page:
<img width="960" height="459" alt="image" src="https://github.com/user-attachments/assets/17cbcd1f-8e9b-4e4d-8caf-24b63c23e3e4" />

Fixed page:
<img width="1340" height="887" alt="image" src="https://github.com/user-attachments/assets/d67d3957-e3db-46d2-b590-a8d516ec8a12" />
