### PR TITLE
fixed the link for my profile in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Our platform offers comprehensive Roblox Jailbreak related features:
 - [Jalenzz16](https://github.com/Jalenzzz) - Co-founder & Lead Front-end Developer
 - [Jakobiis](https://github.com/Jakobiis/) - Co-founder, Lead Back-end Developer & API Architect
 - [linsonder6](https://github.com/linsonder6/) - Bot Scanning Developer
-- [sencha](#) - Bot Scanning Developer
+- [sencha](https://github.com/senchatf) - Bot Scanning Developer
 
 **Jailbreak Changelogs LLC** - The legal entity operating this platform
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Acknowledgements section in README with a corrected GitHub profile link, replacing a placeholder reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JBChangelogs/JailbreakChangelogs/pull/284?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->