### PR TITLE
fix(contributors): JBTC contributor tooltip

### DIFF
--- a/src/components/Contributors/ContributorsClient.tsx
+++ b/src/components/Contributors/ContributorsClient.tsx
@@ -83,7 +83,7 @@ export default function ContributorsClient({
         {
           flag: "is_contributor",
           enabled: true,
-          description: "This user is a trusted tester for Jailbreak Changelogs",
+          description: "This user contributed to Jailbreak Changelogs",
         },
       ],
       link: "https://discord.com/invite/jailbreaktrading",


### PR DESCRIPTION
This fixes the tooltip for contributor on Jailbreak Trading Core showing up as `This user is a trusted tester for Jailbreak Changelogs`, and changes it to `This user contributed to Jailbreak Changelogs`

| Before | After |
| -------------- | ------------- |
|<img width="494" height="317" alt="brave_mwiqQqJZZd" src="https://github.com/user-attachments/assets/a885dc0d-7b26-426b-bc58-c4a7102b0837" /> | <img width="499" height="331" alt="image" src="https://github.com/user-attachments/assets/260c7443-78fd-4e19-99b3-b9c9c5f911d8" /> |
