### PR TITLE
feat(suggestions): add 2 new rules for value suggestions

### DIFF
--- a/src/app/values/suggestions/page.tsx
+++ b/src/app/values/suggestions/page.tsx
@@ -1048,7 +1048,7 @@ function SuggestionGuidelinesDialog({
     "Troll suggesters may be banned from value suggesting at the sole discretion of Value Team managers, website owners, or website moderators.",
     "No botting reactions with alt accounts because any form of manipulation is not allowed on this value list.",
     "Your Roblox account must be at least 30 days old to submit or vote on value suggestions.",
-    "If you are suggesting a value change, you must add atleast 2 common trades at the end of your reasoning.",
+    "If you are suggesting a value change, you must add at least 2 common trades at the end of your reasoning.",
     "You are not allowed to make duplicate suggestions (e.g. suggesting the same change multiple times).",
   ];
 

--- a/src/app/values/suggestions/page.tsx
+++ b/src/app/values/suggestions/page.tsx
@@ -1048,6 +1048,8 @@ function SuggestionGuidelinesDialog({
     "Troll suggesters may be banned from value suggesting at the sole discretion of Value Team managers, website owners, or website moderators.",
     "No botting reactions with alt accounts because any form of manipulation is not allowed on this value list.",
     "Your Roblox account must be at least 30 days old to submit or vote on value suggestions.",
+    "If you are suggesting a value change, you must add atleast 2 common trades at the end of your reasoning.",
+    "You are not allowed to make duplicate suggestions (e.g. suggesting the same change multiple times).",
   ];
 
   return (
@@ -1069,7 +1071,7 @@ function SuggestionGuidelinesDialog({
             Suggestion Guidelines
           </DialogTitle>
           <p className="text-secondary-text text-center text-xs">
-            Last updated: June 2, 2026
+            Last updated: June 4, 2026
           </p>
         </DialogHeader>
 


### PR DESCRIPTION
I have added two new rules to Value Suggestions
<img width="670" height="772" alt="NVIDIA_Overlay_VdMZbuw4jR" src="https://github.com/user-attachments/assets/17d3e10b-2995-4928-be00-5d2eea808d6f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Suggestion Guidelines to require inclusion of at least 2 common trades in reasoning behind suggestions.
  * Added explicit prohibition on duplicate suggestions.
  * Updated guidelines last modified date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->