### PR TITLE
style(changelogs): adjust styling to align with changelog content

### DIFF
--- a/src/components/Changelogs/ChangelogSummary.tsx
+++ b/src/components/Changelogs/ChangelogSummary.tsx
@@ -46,8 +46,11 @@ function MarkdownBody({ children }: { children: string }) {
           </ul>
         ),
         li: ({ children }) => (
-          <li className="flex items-start gap-2">
-            <span className="text-link mt-1 shrink-0">•</span>
+          <li className="flex items-start gap-2 text-sm">
+            <Icon
+              icon="heroicons-outline:arrow-right"
+              className="text-secondary-text mt-1 h-4 w-4 shrink-0"
+            />
             <span>{children}</span>
           </li>
         ),

--- a/src/components/Changelogs/ChangelogSummary.tsx
+++ b/src/components/Changelogs/ChangelogSummary.tsx
@@ -49,6 +49,7 @@ function MarkdownBody({ children }: { children: string }) {
           <li className="flex items-start gap-2 text-sm">
             <Icon
               icon="heroicons-outline:arrow-right"
+              aria-hidden="true"
               className="text-secondary-text mt-1 h-4 w-4 shrink-0"
             />
             <span>{children}</span>


### PR DESCRIPTION
Basically, this makes the bulletpoint icon in the AI Summary be the same as the icon in ChangelogContent.

| Before | After |
| -------- | ------- 
|<img width="189" height="201" alt="image" src="https://github.com/user-attachments/assets/362b14b9-ad8c-45d2-9cdc-3048b76a1c64" /> | <img width="250" height="200" alt="image" src="https://github.com/user-attachments/assets/bf448c96-23aa-4d3c-a8ec-365e5db03bb7" /> |
| <img width="991" height="417" alt="image" src="https://github.com/user-attachments/assets/9333a8c3-a0c8-4aff-8b7c-9b1b57ce320a" /> | <img width="1000" height="415" alt="image" src="https://github.com/user-attachments/assets/a46feab0-e7ab-4a76-86dd-451494704d28" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced changelog list items by replacing text-style bullets with arrow icon indicators for clearer, more polished visual presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->