### PR TITLE
style(changelogs): smoothen changelog summary generating

### DIFF
--- a/src/components/Changelogs/ChangelogSummary.tsx
+++ b/src/components/Changelogs/ChangelogSummary.tsx
@@ -42,7 +42,7 @@ const markdownComponents: Components = {
       <Icon
         icon="heroicons-outline:arrow-right"
         aria-hidden="true"
-        className="text-secondary-textmt-1 h-4 w-4"
+        className="text-secondary-text mt-1 h-4 w-4"
       />
       <span>{children}</span>
     </li>

--- a/src/components/Changelogs/ChangelogSummary.tsx
+++ b/src/components/Changelogs/ChangelogSummary.tsx
@@ -10,6 +10,7 @@ import { PUBLIC_API_URL } from "@/utils/api/api";
 import { buildApiFetchRequest } from "@/utils/api/apiDevToken";
 import { trackEvent } from "@/utils/analytics/rybbit";
 import ReactMarkdown, { Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
 
 interface ChangelogSummaryProps {
   changelogId: number;
@@ -37,7 +38,7 @@ const markdownComponents: Components = {
     <ul className="text-secondary-text space-y-1">{children}</ul>
   ),
   li: ({ children }) => (
-    <li className="flex items-start mt-0.5 gap-2 text-sm">
+    <li className="mt-0.5 flex items-start gap-2 text-sm">
       <Icon
         icon="heroicons-outline:arrow-right"
         aria-hidden="true"
@@ -50,7 +51,9 @@ const markdownComponents: Components = {
 
 function MarkdownBody({ children }: { children: string }) {
   return (
-    <ReactMarkdown components={markdownComponents}>{children}</ReactMarkdown>
+    <ReactMarkdown components={markdownComponents} remarkPlugins={[remarkGfm]}>
+      {children}
+    </ReactMarkdown>
   );
 }
 

--- a/src/components/Changelogs/ChangelogSummary.tsx
+++ b/src/components/Changelogs/ChangelogSummary.tsx
@@ -9,56 +9,48 @@ import { useAuthContext } from "@/contexts/AuthContext";
 import { PUBLIC_API_URL } from "@/utils/api/api";
 import { buildApiFetchRequest } from "@/utils/api/apiDevToken";
 import { trackEvent } from "@/utils/analytics/rybbit";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import ReactMarkdown, { Components } from "react-markdown";
 
 interface ChangelogSummaryProps {
   changelogId: number;
   content: string;
 }
 
+const markdownComponents: Components = {
+  h2: ({ children }) => (
+    <h2 className="text-primary-text mt-4 mb-2 text-base font-semibold first:mt-0">
+      {children}
+    </h2>
+  ),
+  h3: ({ children }) => (
+    <h3 className="text-primary-text mt-3 mb-1 text-sm font-semibold first:mt-0">
+      {children}
+    </h3>
+  ),
+  p: ({ children }) => (
+    <p className="text-secondary-text mb-2 text-sm">{children}</p>
+  ),
+  strong: ({ children }) => (
+    <strong className="text-primary-text font-semibold">{children}</strong>
+  ),
+  ul: ({ children }) => (
+    <ul className="text-secondary-text space-y-1">{children}</ul>
+  ),
+  li: ({ children }) => (
+    <li className="flex items-start mt-0.5 gap-2 text-sm">
+      <Icon
+        icon="heroicons-outline:arrow-right"
+        aria-hidden="true"
+        className="text-secondary-textmt-1 h-4 w-4"
+      />
+      <span>{children}</span>
+    </li>
+  ),
+};
+
 function MarkdownBody({ children }: { children: string }) {
   return (
-    <ReactMarkdown
-      remarkPlugins={[remarkGfm]}
-      components={{
-        h2: ({ children }) => (
-          <h2 className="text-primary-text mt-4 mb-2 text-base font-semibold first:mt-0">
-            {children}
-          </h2>
-        ),
-        h3: ({ children }) => (
-          <h3 className="text-primary-text mt-3 mb-1 text-sm font-semibold first:mt-0">
-            {children}
-          </h3>
-        ),
-        p: ({ children }) => (
-          <p className="text-secondary-text mb-2 text-sm">{children}</p>
-        ),
-        strong: ({ children }) => (
-          <strong className="text-primary-text font-semibold">
-            {children}
-          </strong>
-        ),
-        ul: ({ children }) => (
-          <ul className="text-secondary-text mb-2 space-y-1 text-sm">
-            {children}
-          </ul>
-        ),
-        li: ({ children }) => (
-          <li className="flex items-start gap-2 text-sm">
-            <Icon
-              icon="heroicons-outline:arrow-right"
-              aria-hidden="true"
-              className="text-secondary-text mt-1 h-4 w-4 shrink-0"
-            />
-            <span>{children}</span>
-          </li>
-        ),
-      }}
-    >
-      {children}
-    </ReactMarkdown>
+    <ReactMarkdown components={markdownComponents}>{children}</ReactMarkdown>
   );
 }
 


### PR DESCRIPTION
This PR makes changelog summary generating look more smooth.

| Before | After |
| ------- | -------|
| <video src="https://github.com/user-attachments/assets/fd2c715d-c054-47b5-9897-09b645228d66" width="100%" controls></video> | <video src="https://github.com/user-attachments/assets/aea4db5c-50b9-4dd8-8631-5e071f5b5fde" width="100%" controls></video> |

*Note: All code was vibecoded by Gemini*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization for markdown rendering in changelog components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->