### PR TITLE
style(seasons): enhance styling for contracts, gallery, and season labels

### DIFF
--- a/src/components/Seasons/ImageGallery.tsx
+++ b/src/components/Seasons/ImageGallery.tsx
@@ -9,6 +9,7 @@ import {
   CarouselNext,
   CarouselPrevious,
 } from "@/components/ui/carousel";
+import { useTheme } from "@/contexts/ThemeContext";
 
 interface Reward {
   id: number;
@@ -29,6 +30,8 @@ export default function ImageGallery({ rewards }: ImageGalleryProps) {
     stopOnMouseEnter: true,
     stopOnFocusIn: true,
   });
+
+  const { resolvedTheme } = useTheme();
 
   const filteredRewards = rewards.filter((reward) => {
     // Include rewards with valid images
@@ -84,11 +87,11 @@ export default function ImageGallery({ rewards }: ImageGalleryProps) {
         </CarouselContent>
         <CarouselPrevious
           variant="ghost"
-          className="top-1/2 left-2 z-10 h-8 w-8 -translate-y-1/2 rounded-full bg-black/50 text-white hover:bg-black/70"
+          className={`top-1/2 left-2 z-10 h-8 w-8 -translate-y-1/2 rounded-full text-white hover:bg-black/70 ${resolvedTheme === "dark" ? "bg-black/50" : "bg-white/50"}`}
         />
         <CarouselNext
           variant="ghost"
-          className="top-1/2 right-2 z-10 h-8 w-8 -translate-y-1/2 rounded-full bg-black/50 text-white hover:bg-black/70"
+          className={`top-1/2 right-2 z-10 h-8 w-8 -translate-y-1/2 rounded-full text-white hover:bg-black/70 ${resolvedTheme === "dark" ? "bg-black/50" : "bg-white/50"}`}
         />
       </Carousel>
     </div>

--- a/src/components/Seasons/SeasonContractsClient.tsx
+++ b/src/components/Seasons/SeasonContractsClient.tsx
@@ -17,6 +17,82 @@ export interface SeasonContractProps {
   updatedAt?: number;
 }
 
+type ContractWikiNote = {
+  match: (desc: string, name: string) => boolean;
+  note: string;
+};
+
+const CONTRACT_WIKI_NOTES: ContractWikiNote[] = [
+  // ── Police ──────────────────────────────────────────────────────────────
+  {
+    match: (d, n) =>
+      n === "AccumArrestBounty" ||
+      (d.includes("arrest") && d.includes("worth") && d.includes("bounty")),
+    note: "Goal varies per player (e.g., 5,500–6,000). Displayed value may be approximate.",
+  },
+  {
+    match: (d) =>
+      d.includes("arrest") &&
+      d.includes("criminals") &&
+      !d.includes("worth") &&
+      !d.includes("with a"),
+    note: "The variable goal can be between 12–17 criminals.",
+  },
+  {
+    match: (d) => d.includes("pit maneuver"),
+    note: "The variable goal can be between 5–7 criminals.",
+  },
+  {
+    match: (d) => d.includes("taze"),
+    note: "The variable goal can be between 4–6 criminals.",
+  },
+  {
+    match: (d) => d.includes("arrest a criminal with"),
+    note: "The bounty threshold can be $2,500 or $3,000.",
+  },
+  // ── Criminal ────────────────────────────────────────────────────────────
+  {
+    match: (d) =>
+      d.includes("rob the bank") ||
+      (d.includes("rob") && d.includes("bank") && d.includes("times")),
+    note: "The variable goal can be 3 or 4 bank robberies.",
+  },
+  {
+    match: (d) => d.includes("power plant"),
+    note: "The criminal must not die. If they die, the contract resets and a 15-second penalty is added.",
+  },
+  {
+    match: (d) => d.includes("rob") && d.includes("train"),
+    note: "Works for both trains despite the grammar mistake implying it's only the Cargo Train.",
+  },
+  {
+    match: (d) =>
+      d.includes("take down") && d.includes("police") && d.includes("dying"),
+    note: "The variable goal can be between 4–6 police. If the player dies as a criminal, the contract resets with a 15-second penalty. Police kills on criminals and prisoners also count. Melee kills (Sword or Baton) don't count.",
+  },
+  {
+    match: (d) => d.includes("knock over"),
+    note: "The variable goal can be between 400–410 items.",
+  },
+  {
+    match: (d) => d.includes("deal") && d.includes("damage"),
+    note: "The variable goal can be between 1,800–2,200 damage.",
+  },
+  {
+    match: (d) => d.includes("small stores"),
+    note: "Must rob both the Donut Store and Gas Station without dying. Can rob the same store twice. If the criminal dies, the contract resets with a 15-second penalty.",
+  },
+  {
+    match: (d) => d.includes("collect a bounty"),
+    note: "The criminal must not die. If they die, the contract resets and a 15-second penalty is added.",
+  },
+];
+
+function getContractNote(description: string, name: string): string | null {
+  const d = description.toLowerCase();
+  return CONTRACT_WIKI_NOTES.find((n) => n.match(d, name))?.note ?? null;
+}
+
 export default function SeasonContractsClient({
   contracts,
   updatedAt,
@@ -40,46 +116,27 @@ export default function SeasonContractsClient({
 
   return (
     <div className="space-y-12">
-      {formatUpdatedAt && (
-        <div className="text-center">
-          <span className="border-border-card bg-secondary-bg text-secondary-text inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm backdrop-blur-sm">
-            Last updated: {formatUpdatedAt}
-          </span>
-        </div>
-      )}
-
       {(["Criminal", "Police"] as const).map((team) => (
         <div key={team} className="space-y-6">
           {/* Team Header */}
           <div className="text-center">
             <div className="relative inline-block">
-              <div
-                className={`relative rounded-2xl border px-8 py-4 ${
-                  team === "Criminal"
-                    ? "border-orange-500/30 bg-orange-500/10"
-                    : "border-blue-500/30 bg-blue-500/10"
-                }`}
-              >
+              <div className="border-border-card bg-secondary-bg relative rounded-2xl border px-8 py-4">
                 <div className="flex items-center justify-center gap-4">
-                  {/* Team Icon */}
                   {team === "Criminal" ? (
                     <Icon
                       icon="ri:criminal-fill"
-                      className="text-orange-500 h-8 w-8 shrink-0 sm:h-10 sm:w-10"
+                      className="text-primary-text h-8 w-8 shrink-0 sm:h-10 sm:w-10"
                       inline={true}
                     />
                   ) : (
                     <Icon
                       icon="game-icons:police-officer-head"
-                      className="text-blue-500 h-8 w-8 shrink-0 sm:h-10 sm:w-10"
+                      className="text-primary-text h-8 w-8 shrink-0 sm:h-10 sm:w-10"
                       inline={true}
                     />
                   )}
-                  <span
-                    className={`text-2xl font-bold tracking-wide uppercase ${
-                      team === "Criminal" ? "text-orange-500" : "text-blue-500"
-                    }`}
-                  >
+                  <span className="text-primary-text text-2xl font-bold tracking-wide uppercase">
                     {team} Contracts
                   </span>
                 </div>
@@ -89,94 +146,114 @@ export default function SeasonContractsClient({
 
           {/* Contracts Grid */}
           <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-            {grouped[team].map((c, idx) => (
-              <div
-                key={`${team}-${c.name}-${idx}`}
-                className={`group relative flex flex-col overflow-hidden rounded-2xl border transition-all duration-300 ${
-                  team === "Criminal"
-                    ? "border-orange-500/30 bg-orange-500/5 hover:border-orange-500/60"
-                    : "border-blue-500/30 bg-blue-500/5 hover:border-blue-500/60"
-                }`}
-              >
-                {/* Season Pass Corner Badge */}
-                {c.reqseasonpass && (
-                  <div className="absolute top-3 right-3 z-10">
-                    <span
-                      className={`inline-flex h-6 items-center rounded-lg border px-2.5 text-xs leading-none font-medium backdrop-blur-xl ${
-                        team === "Criminal"
-                          ? "border-orange-500/30 bg-orange-950/40 text-orange-200"
-                          : "border-blue-500/30 bg-blue-950/40 text-blue-200"
-                      }`}
-                    >
-                      Season Pass
-                    </span>
-                  </div>
-                )}
-
-                {/* Contract Header */}
+            {grouped[team].map((c, idx) => {
+              const wikiNote = getContractNote(c.description, c.name);
+              return (
                 <div
-                  className={`px-4 py-3 ${
-                    team === "Criminal" ? "bg-orange-500/10" : "bg-blue-500/10"
+                  key={`${team}-${c.name}-${idx}`}
+                  className={`group relative flex flex-col overflow-hidden rounded-2xl border transition-all duration-300 ${
+                    c.reqseasonpass
+                      ? "border-supporter-gold-border/50"
+                      : "border-border-card"
                   }`}
+                  style={
+                    c.reqseasonpass
+                      ? {
+                          boxShadow:
+                            "0 0 18px color-mix(in srgb, var(--color-supporter-gold-border) 12%, transparent)",
+                        }
+                      : undefined
+                  }
                 >
+                  {/* Contract Header */}
                   <div
-                    className={`text-2xl uppercase ${bangers.className} ${
-                      team === "Criminal" ? "text-orange-400" : "text-blue-400"
+                    className={`flex items-center justify-between px-4 py-3 ${
+                      c.reqseasonpass
+                        ? "bg-supporter-gold-bg"
+                        : "bg-secondary-bg"
                     }`}
                   >
-                    Contract {idx + 1}
-                  </div>
-                </div>
-
-                {/* Contract Body */}
-                <div className="relative flex flex-1 flex-col px-4 py-6">
-                  <div className="relative z-10 flex h-full flex-col">
-                    {/* Task Description */}
-                    <div className="mb-4 flex flex-1 items-center justify-center">
-                      <div className="text-primary-text text-center text-xl leading-tight font-bold">
-                        {c.description}
-                      </div>
+                    <div
+                      className={`text-2xl uppercase ${bangers.className} ${
+                        c.reqseasonpass
+                          ? "text-warning-dark"
+                          : "text-primary-text"
+                      }`}
+                    >
+                      Contract {idx + 1}
                     </div>
-
-                    {/* Special Note */}
-                    {c.name === "AccumArrestBounty" && (
-                      <div className="bg-button-info/10 border-button-info mb-4 rounded-lg border p-3">
-                        <div className="text-primary-text flex items-center gap-2 text-sm">
-                          <span className="font-medium">Note:</span>
-                          <span>
-                            This goal varies per player (e.g., 5,500–6,000).
-                            Displayed value may be approximate.
-                          </span>
-                        </div>
-                      </div>
+                    {c.reqseasonpass && (
+                      <span className="border-supporter-gold-border/40 bg-supporter-gold-bg text-warning-dark inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-1 text-xs font-semibold">
+                        <Icon
+                          icon="mdi:crown"
+                          className="h-3.5 w-3.5"
+                          inline={true}
+                        />
+                        Season Pass
+                      </span>
                     )}
-                    {/* Reward Section */}
-                    <div className="mt-auto">
-                      <div
-                        className={`relative rounded-xl border px-4 py-3 transition-colors ${
-                          team === "Criminal"
-                            ? "border-orange-500/40 bg-orange-500/10 shadow-[0_0_15px_rgba(249,115,22,0.15)]"
-                            : "border-blue-500/40 bg-blue-500/10 shadow-[0_0_15px_rgba(59,130,246,0.15)]"
-                        }`}
-                      >
-                        <div
-                          className={`text-2xl uppercase ${bangers.className} text-center ${
-                            team === "Criminal"
-                              ? "text-orange-600 dark:text-orange-400"
-                              : "text-blue-600 dark:text-blue-400"
-                          }`}
-                        >
-                          REWARD: {c.reward} XP
+                  </div>
+
+                  {/* Contract Body */}
+                  <div className="bg-secondary-bg relative flex flex-1 flex-col px-4 py-6">
+                    <div className="relative z-10 flex h-full flex-col">
+                      {/* Task Description */}
+                      <div className="mb-4 flex flex-1 items-center justify-center">
+                        <div className="text-primary-text text-center text-xl leading-tight font-bold">
+                          {c.description}
+                        </div>
+                      </div>
+
+                      {/* Wiki Note */}
+                      {wikiNote && (
+                        <div className="bg-button-info/10 border-button-info mb-4 rounded-lg border p-3">
+                          <div className="text-primary-text text-center text-sm">
+                            {wikiNote}
+                          </div>
+                        </div>
+                      )}
+
+                      {/* Reward Section */}
+                      <div className="mt-auto">
+                        <div className="relative">
+                          <div className="bg-primary-bg absolute inset-0 rounded-xl opacity-50 blur-sm"></div>
+                          <div className="border-border-card bg-tertiary-bg relative rounded-xl border px-4 py-3">
+                            <div
+                              className={`text-primary-text text-2xl uppercase ${bangers.className} text-center`}
+                            >
+                              REWARD: {c.reward} XP
+                            </div>
+                          </div>
                         </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </div>
       ))}
+
+      <div className="flex items-center justify-between">
+        <p className="text-secondary-text text-xs">
+          Contract notes sourced from the{" "}
+          <a
+            href="https://jailbreak.fandom.com/wiki/Contracts"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-link hover:text-link-hover underline underline-offset-2 transition-colors"
+          >
+            Jailbreak Wiki
+          </a>
+        </p>
+        {formatUpdatedAt && (
+          <p className="text-secondary-text text-sm">
+            <span className="font-semibold">Last Updated:</span>{" "}
+            {formatUpdatedAt}
+          </p>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/Seasons/SeasonContractsClient.tsx
+++ b/src/components/Seasons/SeasonContractsClient.tsx
@@ -53,23 +53,33 @@ export default function SeasonContractsClient({
           {/* Team Header */}
           <div className="text-center">
             <div className="relative inline-block">
-              <div className="border-border-card bg-secondary-bg relative rounded-2xl border px-8 py-4">
+              <div
+                className={`relative rounded-2xl border px-8 py-4 ${
+                  team === "Criminal"
+                    ? "border-orange-500/30 bg-orange-500/10"
+                    : "border-blue-500/30 bg-blue-500/10"
+                }`}
+              >
                 <div className="flex items-center justify-center gap-4">
                   {/* Team Icon */}
                   {team === "Criminal" ? (
                     <Icon
                       icon="ri:criminal-fill"
-                      className="text-primary-text h-8 w-8 shrink-0 sm:h-10 sm:w-10"
+                      className="text-orange-500 h-8 w-8 shrink-0 sm:h-10 sm:w-10"
                       inline={true}
                     />
                   ) : (
                     <Icon
                       icon="game-icons:police-officer-head"
-                      className="text-primary-text h-8 w-8 shrink-0 sm:h-10 sm:w-10"
+                      className="text-blue-500 h-8 w-8 shrink-0 sm:h-10 sm:w-10"
                       inline={true}
                     />
                   )}
-                  <span className="text-primary-text text-2xl font-bold tracking-wide uppercase">
+                  <span
+                    className={`text-2xl font-bold tracking-wide uppercase ${
+                      team === "Criminal" ? "text-orange-500" : "text-blue-500"
+                    }`}
+                  >
                     {team} Contracts
                   </span>
                 </div>
@@ -82,28 +92,44 @@ export default function SeasonContractsClient({
             {grouped[team].map((c, idx) => (
               <div
                 key={`${team}-${c.name}-${idx}`}
-                className="group border-border-card relative flex flex-col overflow-hidden rounded-2xl border transition-all duration-300"
+                className={`group relative flex flex-col overflow-hidden rounded-2xl border transition-all duration-300 ${
+                  team === "Criminal"
+                    ? "border-orange-500/30 bg-orange-500/5 hover:border-orange-500/60"
+                    : "border-blue-500/30 bg-blue-500/5 hover:border-blue-500/60"
+                }`}
               >
                 {/* Season Pass Corner Badge */}
                 {c.reqseasonpass && (
                   <div className="absolute top-3 right-3 z-10">
-                    <span className="text-primary-text border-border-card bg-tertiary-bg/40 inline-flex h-6 items-center rounded-lg border px-2.5 text-xs leading-none font-medium backdrop-blur-xl">
+                    <span
+                      className={`inline-flex h-6 items-center rounded-lg border px-2.5 text-xs leading-none font-medium backdrop-blur-xl ${
+                        team === "Criminal"
+                          ? "border-orange-500/30 bg-orange-950/40 text-orange-200"
+                          : "border-blue-500/30 bg-blue-950/40 text-blue-200"
+                      }`}
+                    >
                       Season Pass
                     </span>
                   </div>
                 )}
 
                 {/* Contract Header */}
-                <div className="bg-secondary-bg px-4 py-3">
+                <div
+                  className={`px-4 py-3 ${
+                    team === "Criminal" ? "bg-orange-500/10" : "bg-blue-500/10"
+                  }`}
+                >
                   <div
-                    className={`text-primary-text text-2xl uppercase ${bangers.className}`}
+                    className={`text-2xl uppercase ${bangers.className} ${
+                      team === "Criminal" ? "text-orange-400" : "text-blue-400"
+                    }`}
                   >
                     Contract {idx + 1}
                   </div>
                 </div>
 
                 {/* Contract Body */}
-                <div className="bg-secondary-bg relative flex flex-1 flex-col px-4 py-6">
+                <div className="relative flex flex-1 flex-col px-4 py-6">
                   <div className="relative z-10 flex h-full flex-col">
                     {/* Task Description */}
                     <div className="mb-4 flex flex-1 items-center justify-center">
@@ -124,17 +150,23 @@ export default function SeasonContractsClient({
                         </div>
                       </div>
                     )}
-
                     {/* Reward Section */}
                     <div className="mt-auto">
-                      <div className="relative">
-                        <div className="bg-primary-bg absolute inset-0 rounded-xl opacity-50 blur-sm"></div>
-                        <div className="border-border-card bg-tertiary-bg relative rounded-xl border px-4 py-3">
-                          <div
-                            className={`text-primary-text text-2xl uppercase ${bangers.className} text-center`}
-                          >
-                            REWARD: {c.reward} XP
-                          </div>
+                      <div
+                        className={`relative rounded-xl border px-4 py-3 transition-colors ${
+                          team === "Criminal"
+                            ? "border-orange-500/40 bg-orange-500/10 shadow-[0_0_15px_rgba(249,115,22,0.15)]"
+                            : "border-blue-500/40 bg-blue-500/10 shadow-[0_0_15px_rgba(59,130,246,0.15)]"
+                        }`}
+                      >
+                        <div
+                          className={`text-2xl uppercase ${bangers.className} text-center ${
+                            team === "Criminal"
+                              ? "text-orange-600 dark:text-orange-400"
+                              : "text-blue-600 dark:text-blue-400"
+                          }`}
+                        >
+                          REWARD: {c.reward} XP
                         </div>
                       </div>
                     </div>

--- a/src/components/Seasons/SeasonDetailsClient.tsx
+++ b/src/components/Seasons/SeasonDetailsClient.tsx
@@ -363,7 +363,7 @@ export default function SeasonDetailsClient({
                           )}
                           {reward.exclusive === "True" && (
                             <span className="text-primary-text border-border-card bg-tertiary-bg/40 inline-flex h-6 items-center rounded-lg border px-2.5 text-xs leading-none font-medium backdrop-blur-xl">
-                              Exclusive
+                              Season Pass
                             </span>
                           )}
                         </div>


### PR DESCRIPTION
This PR focuses on changing styling for season-related pages. I fixed image gallery so the next/previous buttons change with the theme. Lastly, I changed the season pass label from "Exclusive" to "Season Pass".

| Before | After |
|--------|--------|
| <img width="91" height="60" alt="image" src="https://github.com/user-attachments/assets/6e0f338c-26bd-4ed3-90f0-43df81522a69" />| <img width="120" height="52" alt="brave_ORziYdYwnw" src="https://github.com/user-attachments/assets/cf76ff8c-b3f5-469d-8535-9d92655f2dfe" />|
| <img width="526" height="311" alt="brave_jifbboFK09" src="https://github.com/user-attachments/assets/a4b519bc-679e-41e4-84ee-23cce96261da" /> | <img width="525" height="290" alt="brave_P8sDJUwJJH" src="https://github.com/user-attachments/assets/9caa25ae-146a-4885-ad8a-5b80aa5b908a" />|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style Updates**
  * Enhanced theme-aware styling for carousel navigation controls with dynamic dark mode support.
  * Updated exclusive reward badge text to "Season Pass".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->